### PR TITLE
Fixing Memory leaks for Animations

### DIFF
--- a/lib/src/chart.dart
+++ b/lib/src/chart.dart
@@ -74,6 +74,8 @@ class _ChartState extends State<Chart> with TickerProviderStateMixin {
   @override
   void dispose() {
     _controller.dispose();
+    widget.layers.forEach((e) => e.dispose());
+    _disposeOldLayers();
     super.dispose();
   }
 

--- a/lib/src/chart.dart
+++ b/lib/src/chart.dart
@@ -87,7 +87,7 @@ class _ChartState extends State<Chart> with TickerProviderStateMixin {
         Expanded(
           child: AnimatedBuilder(
             animation: _controller,
-            builder: (_, __) => ChartTouchDetector<dynamic>(
+            builder: (_, __) => ChartTouchDetector<ChartDataItem>(
               onShapes: () => _touchableShapes,
               onTap: ((touchPosition, data) => setState(() {
                     _touchedData = data == null

--- a/lib/src/chart.dart
+++ b/lib/src/chart.dart
@@ -75,7 +75,6 @@ class _ChartState extends State<Chart> with TickerProviderStateMixin {
   void dispose() {
     _controller.dispose();
     widget.layers.forEach((e) => e.dispose());
-    _disposeOldLayers();
     super.dispose();
   }
 

--- a/lib/src/models/animation/chart_color_animation.dart
+++ b/lib/src/models/animation/chart_color_animation.dart
@@ -3,6 +3,8 @@ part of 'chart_animation.dart';
 /// Provides color animation values.
 class ChartColorAnimation implements ChartAnimation {
   Animation<Color?>? _animation;
+  CurvedAnimation? _listener;
+
   Color _lastColor = Colors.transparent;
 
   ChartColorAnimation();
@@ -21,6 +23,7 @@ class ChartColorAnimation implements ChartAnimation {
   @override
   void dispose() {
     _animation = null;
+    _listener?.dispose();
   }
 
   /// Initialize animation.
@@ -31,15 +34,14 @@ class ChartColorAnimation implements ChartAnimation {
     Color? initialColor,
     ChartColorAnimation? oldAnimation,
   }) {
-    final Animation<Color?> animation = ColorTween(
+    _listener?.dispose();
+    _listener = CurvedAnimation(
+      parent: controller,
+      curve: curve,
+    );
+    _animation = ColorTween(
       begin: oldAnimation?._lastColor ?? initialColor ?? Colors.transparent,
       end: color,
-    ).animate(
-      CurvedAnimation(
-        parent: controller,
-        curve: curve,
-      ),
-    );
-    _animation = animation;
+    ).animate(_listener!);
   }
 }

--- a/lib/src/models/animation/chart_position_animation.dart
+++ b/lib/src/models/animation/chart_position_animation.dart
@@ -3,6 +3,7 @@ part of 'chart_animation.dart';
 /// Provides position animation values.
 class ChartPositionAnimation implements ChartAnimation {
   Animation<Offset>? _animation;
+  CurvedAnimation? _listener;
   Offset _lastPosition = Offset.zero;
 
   ChartPositionAnimation();
@@ -21,6 +22,7 @@ class ChartPositionAnimation implements ChartAnimation {
   @override
   void dispose() {
     _animation = null;
+    _listener?.dispose();
   }
 
   /// Initialize animation.
@@ -31,15 +33,14 @@ class ChartPositionAnimation implements ChartAnimation {
     Offset? initialPosition,
     ChartPositionAnimation? oldAnimation,
   }) {
-    final Animation<Offset> animation = Tween<Offset>(
+    _listener?.dispose();
+    _listener = CurvedAnimation(
+      parent: controller,
+      curve: curve,
+    );
+    _animation = Tween<Offset>(
       begin: oldAnimation?._lastPosition ?? initialPosition ?? position,
       end: position,
-    ).animate(
-      CurvedAnimation(
-        parent: controller,
-        curve: curve,
-      ),
-    );
-    _animation = animation;
+    ).animate(_listener!);
   }
 }

--- a/lib/src/models/animation/chart_size_animation.dart
+++ b/lib/src/models/animation/chart_size_animation.dart
@@ -3,6 +3,7 @@ part of 'chart_animation.dart';
 /// Provides size animation values.
 class ChartSizeAnimation implements ChartAnimation {
   Animation<Size>? _animation;
+  CurvedAnimation? _listener;
   Size _lastSize = Size.zero;
 
   ChartSizeAnimation();
@@ -21,6 +22,7 @@ class ChartSizeAnimation implements ChartAnimation {
   @override
   void dispose() {
     _animation = null;
+    _listener?.dispose();
   }
 
   /// Initialize animation.
@@ -31,15 +33,14 @@ class ChartSizeAnimation implements ChartAnimation {
     Size? initialSize,
     ChartSizeAnimation? oldAnimation,
   }) {
-    final Animation<Size> animation = Tween<Size>(
+    _listener?.dispose();
+    _listener = CurvedAnimation(
+      parent: controller,
+      curve: curve,
+    );
+    _animation = Tween<Size>(
       begin: oldAnimation?._lastSize ?? initialSize ?? size,
       end: size,
-    ).animate(
-      CurvedAnimation(
-        parent: controller,
-        curve: curve,
-      ),
-    );
-    _animation = animation;
+    ).animate(_listener!);
   }
 }

--- a/lib/src/models/animation/chart_text_style_animation.dart
+++ b/lib/src/models/animation/chart_text_style_animation.dart
@@ -3,6 +3,8 @@ part of 'chart_animation.dart';
 /// Provides text style animation values.
 class ChartTextStyleAnimation implements ChartAnimation {
   Animation<TextStyle>? _animation;
+  CurvedAnimation? _listener;
+
   TextStyle _lastTextStyle = const TextStyle(
     color: Colors.transparent,
   );
@@ -26,6 +28,7 @@ class ChartTextStyleAnimation implements ChartAnimation {
   @override
   void dispose() {
     _animation = null;
+    _listener?.dispose();
   }
 
   /// Initialize animation.
@@ -36,19 +39,18 @@ class ChartTextStyleAnimation implements ChartAnimation {
     TextStyle? initialTextSyle,
     ChartTextStyleAnimation? oldAnimation,
   }) {
-    final Animation<TextStyle> animation = TextStyleTween(
+    _listener?.dispose();
+    _listener = CurvedAnimation(
+      parent: controller,
+      curve: curve,
+    );
+    _animation = TextStyleTween(
       begin: oldAnimation?._lastTextStyle ??
           initialTextSyle ??
           const TextStyle(
             color: Colors.transparent,
           ),
       end: textStyle,
-    ).animate(
-      CurvedAnimation(
-        parent: controller,
-        curve: curve,
-      ),
-    );
-    _animation = animation;
+    ).animate(_listener!);
   }
 }

--- a/lib/src/models/line/chart_line_data_item.dart
+++ b/lib/src/models/line/chart_line_data_item.dart
@@ -61,6 +61,7 @@ class ChartLineDataItem extends ChartDataItem {
   @override
   void dispose() {
     _value.dispose();
+    _touch.dispose();
   }
 
   /// Initialize touch area animations.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mrx_charts
 description: Simple, high-performance Flutter charts with beautiful animations.
-version: 0.1.3
+version: 0.1.4
 repository: https://github.com/merixstudio/mrx-flutter-charts
 issue_tracker: https://github.com/merixstudio/mrx-flutter-charts/issues
 homepage:


### PR DESCRIPTION
Thanks for this library. The current version holds 3 memory leaks tho.

1. **Chart::dispose**
Neither the current widget layers, nor the old layers are disposed by the regular lifecycle events.
This may not be a problem, as all memory is most likely is to be freed, when the AnimationController dispose is called- but you never know.

2. **ChartLineDataItem::dispose**
You forgot to call dispose the touch events.

3. **Chart::didUpdateWidget**
When calling `setState` and start the animation you forget to dispose those `CurvedAnimation`s, which then are registered on the AnimationHandler. 
Also, setting the `_animation` member to `null` is basically a no-op, as need to dispose the animation. I have included a screenshot where you can easily see the insane big amount of closures held by the `AnimationController`.
The leaking observer, then has to update for too many listeners resulting in poor performance.

![Screenshot 2023-02-16 at 00 57 10](https://user-images.githubusercontent.com/20244674/219223668-5b0a3d14-9dbc-4e7b-8c98-ca54c6cb63ec.png)

